### PR TITLE
Release/v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.3] - 2025-06-06
+
+- Bumped pipelex to v0.2.14: generalized the new `execute_pipeline` method, enabling to track pipelines from beginning to end with inference cost reporting
+
 ## [v0.0.2] - 2025-05-30
 
 - Added tests folder and GHA and fixed makefile (runtests -> gha-tests)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ make merge-check-pyright	  - Run pyright merge check without updating files
 
 make rl                       - Shorthand -> reinitlibraries
 make s                        - Shorthand -> run-setup
-make init                     - Run pipelex init
+make init                     - Run pipelex init-libraries and pipelex init-config
 make gha-tests		          - Run tests for github actions (exit on first failure) (no inference, no gha_disabled)
 make test                     - Run unit tests (no inference)
 make test-with-prints         - Run tests with prints (no inference)
@@ -117,13 +117,15 @@ env: check-uv
 
 init: env
 	$(call PRINT_TITLE,"Running `pipelex init` with overwrite")
-	pipelex init
+	pipelex init-libraries && \
+	pipelex init-config
 
 install: env
 	$(call PRINT_TITLE,"Installing dependencies")
 	@. $(VIRTUAL_ENV)/bin/activate && \
 	uv pip install -e ".[dev]" && \
-	pipelex init && \
+	pipelex init-libraries && \
+	pipelex init-config && \
 	echo "Installed Pipelex dependencies in ${VIRTUAL_ENV} with all extras and initialized Pipelex";
 	
 

--- a/pipelex.toml
+++ b/pipelex.toml
@@ -9,26 +9,38 @@ api_key_method = "env"
 # This overrrides the defaults set for any llm handle
 "gpt-4o-mini" = "openai"
 
-[cogt.llm_config.openai_openai_config]
+[plugins]
+
+[plugins.openai_config]
+image_output_compression = 100
 api_key_method = "env"
 
-[cogt.llm_config.azure_openai_config]
+[plugins.azure_openai_config]
 api_key_method = "env"
 
-[cogt.llm_config.perplexity_config]
+# TODO: handle multiple azure openai accounts with different resource groups and account names for various llm model
+
+[plugins.perplexity_config]
 api_key_method = "env"
 
-[cogt.llm_config.vertexai_config]
+[plugins.xai_config]
 api_key_method = "env"
 
-[cogt.llm_config.mistral_config]
+[plugins.vertexai_config]
 api_key_method = "env"
 
-[cogt.llm_config.anthropic_config]
+[plugins.mistral_config]
 api_key_method = "env"
 
-[cogt.llm_config.bedrock_config]
+[plugins.bedrock_config]
 client_method = "aioboto3"
+
+[plugins.anthropic_config]
+claude_4_reduced_tokens_limit = 8192  # use "unlimited" to enable the full 32/64K tokens Opus/Sonet but it raises streaming/timeout issues
+api_key_method = "env"
+
+[plugins.custom_endpoint_config]
+api_key_method = "env"
 
 ####################################################################################################
 # OCR config

--- a/pipelex_libraries/llm_deck/base_llm_deck.toml
+++ b/pipelex_libraries/llm_deck/base_llm_deck.toml
@@ -7,8 +7,10 @@
 # Match a llm_handle with a complete blueprint (llm_name, llm_version and llm_platform_choice).
 [llm_handles]
 gpt-4o-2024-08-06 = { llm_name = "gpt-4o", llm_version = "2024-08-06" }
-best-claude = "claude-3-7-sonnet"
+best-claude = "claude-4-opus"
 best-gemini = "gemini-2.5-pro"
+best-mistral = "mistral-large"
+best-grok = "grok-3"
 
 ####################################################################################################
 # LLM Presets
@@ -52,6 +54,7 @@ llm_to_engineer = { llm_handle = "best-claude", temperature = 0.5 }
 llm_to_write_imgg_prompt = { llm_handle = "best-claude", temperature = 0.2 }
 llm_to_describe_img = { llm_handle = "best-claude", temperature = 0.5 }
 llm_to_design_fashion = { llm_handle = "best-claude", temperature = 0.7 }
+llm_for_img_to_text = { llm_handle = "best-claude", temperature = 0.1 }
 
 # Extraction skills
 llm_to_extract_diagram = { llm_handle = "best-claude", temperature = 0.5 }
@@ -60,8 +63,6 @@ llm_to_extract_invoice_from_scan = { llm_handle = "best-claude", temperature = 0
 llm_to_extract_legal_terms = { llm_handle = "best-claude", temperature = 0.1 }
 llm_to_extract_tables = { llm_handle = "best-claude", temperature = 0.1 }
 
-# OCR skills
-llm_for_ocr = { llm_handle = "best-claude", temperature = 0.1 }
 
 ####################################################################################################
 # LLM Choices

--- a/pipelex_libraries/llm_integrations/anthropic.toml
+++ b/pipelex_libraries/llm_integrations/anthropic.toml
@@ -42,3 +42,23 @@ max_prompt_images = 100
 cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
 platform_llm_id = { anthropic = "claude-3-7-sonnet-20250219", bedrock_anthropic = "us.anthropic.claude-3-7-sonnet-20250219-v1:0" }
 default_platform = "anthropic"
+
+
+["claude-4".claude-4-sonnet.latest]
+max_tokens = 64000
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 100
+cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
+platform_llm_id = { anthropic = "claude-sonnet-4-20250514", bedrock_anthropic = "us.anthropic.claude-sonnet-4-20250514-v1:0" }
+default_platform = "anthropic"
+
+
+["claude-4".claude-4-opus.latest]
+max_tokens = 32000
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 100
+cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
+platform_llm_id = { anthropic = "claude-opus-4-20250514", bedrock_anthropic = "us.anthropic.claude-opus-4-20250514-v1:0" }
+default_platform = "anthropic"

--- a/pipelex_libraries/llm_integrations/custom.toml
+++ b/pipelex_libraries/llm_integrations/custom.toml
@@ -5,11 +5,25 @@ is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "gemma3:4b" }
+platform_llm_id = { custom_llm = "gemma3:4b" }
 
 [custom-llama-4."llama4:scout".latest]
 is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "llama4:scout" }
+platform_llm_id = { custom_llm = "llama4:scout" }
+
+["custom-mistral-small3.1"."mistral-small3.1".latest]
+is_gen_object_supported = false
+is_vision_supported = true
+max_prompt_images = 3000
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "mistral-small3.1:24b" }
+
+["custom-qwen3"."qwen3:8b".latest]
+is_gen_object_supported = false
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "qwen3:8b" }
+# TODO: support <think> tokens

--- a/pipelex_libraries/llm_integrations/vertexai.toml
+++ b/pipelex_libraries/llm_integrations/vertexai.toml
@@ -5,32 +5,39 @@ is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.075, output = 0.3 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-flash" }
+platform_llm_id = { vertexai = "google/gemini-1.5-flash" }
 
 [gemini."gemini-1.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 1.25, output = 5.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-pro" }
+platform_llm_id = { vertexai = "google/gemini-1.5-pro" }
 
 [gemini."gemini-2.0-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.1, output = 0.4 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.0-flash" }
+platform_llm_id = { vertexai = "google/gemini-2.0-flash" }
 
 [gemini."gemini-2.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.0, output = 0.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-pro-preview-05-06" }
+platform_llm_id = { vertexai = "google/gemini-2.5-pro-preview-05-06" }
+
+[gemini."gemini-2.5-flash"."2025-04-17"]
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 3000
+cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-04-17" }
 
 [gemini."gemini-2.5-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-flash-preview-04-17" }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-05-20" }

--- a/pipelex_libraries/llm_integrations/xai.toml
+++ b/pipelex_libraries/llm_integrations/xai.toml
@@ -1,0 +1,25 @@
+
+[grok-3.grok-3.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 3, output = 15 }
+platform_llm_id = { xai = "grok-3-latest" }
+
+[grok-3.grok-3-mini.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0.3, output = 0.5 }
+platform_llm_id = { xai = "grok-3-mini-latest" }
+
+[grok-3.grok-3-fast.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 5, output = 25 }
+platform_llm_id = { xai = "grok-3-fast-latest" }
+
+
+[grok-3.grok-3-mini-fast.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0.15, output = 4 }
+platform_llm_id = { xai = "grok-3-mini-fast-latest" }

--- a/pipelex_libraries/pipelines/base_library/documents.toml
+++ b/pipelex_libraries/pipelines/base_library/documents.toml
@@ -16,3 +16,11 @@ output = "PageContent"
 pdf = "pdf"
 page_images = true
 page_views = false
+
+[pipe.extract_page_contents_and_views_from_pdf]
+PipeOcr = "Extract page contents from a PDF document as well aspage views"
+input = "PDF"
+output = "PageContent"
+pdf = "pdf"
+page_images = true
+page_views = true

--- a/pipelex_libraries/pipelines/base_library/questions.py
+++ b/pipelex_libraries/pipelines/base_library/questions.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from enum import StrEnum
 from typing import Generic, List, Literal, Optional, TypeVar, Union
 
-from pipelex import pretty_print
 from pipelex.core.stuff_content import StructuredContent
+from pipelex.types import StrEnum
 from pydantic import Field, model_validator
 from typing_extensions import Self, override
 
@@ -58,12 +57,6 @@ class ThoughtfulAnswer(StructuredContent):
     the_counter: str
     the_lesson: str
     the_answer: str
-
-    def pretty_print(self):
-        pretty_print(self.the_trap, title="The trap", border_style="bright_red")
-        pretty_print(self.the_counter, title="The counter", border_style="bright_yellow")
-        pretty_print(self.the_lesson, title="The lesson", border_style="blue")
-        pretty_print(self.the_answer, title="The answer", border_style="green")
 
 
 T = TypeVar("T")

--- a/pipelex_mcp/pipelex_libraries/llm_deck/base_llm_deck.toml
+++ b/pipelex_mcp/pipelex_libraries/llm_deck/base_llm_deck.toml
@@ -7,8 +7,10 @@
 # Match a llm_handle with a complete blueprint (llm_name, llm_version and llm_platform_choice).
 [llm_handles]
 gpt-4o-2024-08-06 = { llm_name = "gpt-4o", llm_version = "2024-08-06" }
-best-claude = "claude-3-7-sonnet"
+best-claude = "claude-4-opus"
 best-gemini = "gemini-2.5-pro"
+best-mistral = "mistral-large"
+best-grok = "grok-3"
 
 ####################################################################################################
 # LLM Presets
@@ -52,6 +54,7 @@ llm_to_engineer = { llm_handle = "best-claude", temperature = 0.5 }
 llm_to_write_imgg_prompt = { llm_handle = "best-claude", temperature = 0.2 }
 llm_to_describe_img = { llm_handle = "best-claude", temperature = 0.5 }
 llm_to_design_fashion = { llm_handle = "best-claude", temperature = 0.7 }
+llm_for_img_to_text = { llm_handle = "best-claude", temperature = 0.1 }
 
 # Extraction skills
 llm_to_extract_diagram = { llm_handle = "best-claude", temperature = 0.5 }
@@ -60,8 +63,6 @@ llm_to_extract_invoice_from_scan = { llm_handle = "best-claude", temperature = 0
 llm_to_extract_legal_terms = { llm_handle = "best-claude", temperature = 0.1 }
 llm_to_extract_tables = { llm_handle = "best-claude", temperature = 0.1 }
 
-# OCR skills
-llm_for_ocr = { llm_handle = "best-claude", temperature = 0.1 }
 
 ####################################################################################################
 # LLM Choices

--- a/pipelex_mcp/pipelex_libraries/llm_integrations/anthropic.toml
+++ b/pipelex_mcp/pipelex_libraries/llm_integrations/anthropic.toml
@@ -42,3 +42,23 @@ max_prompt_images = 100
 cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
 platform_llm_id = { anthropic = "claude-3-7-sonnet-20250219", bedrock_anthropic = "us.anthropic.claude-3-7-sonnet-20250219-v1:0" }
 default_platform = "anthropic"
+
+
+["claude-4".claude-4-sonnet.latest]
+max_tokens = 64000
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 100
+cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
+platform_llm_id = { anthropic = "claude-sonnet-4-20250514", bedrock_anthropic = "us.anthropic.claude-sonnet-4-20250514-v1:0" }
+default_platform = "anthropic"
+
+
+["claude-4".claude-4-opus.latest]
+max_tokens = 32000
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 100
+cost_per_million_tokens_usd = { input = 3.0, output = 15.0 }
+platform_llm_id = { anthropic = "claude-opus-4-20250514", bedrock_anthropic = "us.anthropic.claude-opus-4-20250514-v1:0" }
+default_platform = "anthropic"

--- a/pipelex_mcp/pipelex_libraries/llm_integrations/custom.toml
+++ b/pipelex_mcp/pipelex_libraries/llm_integrations/custom.toml
@@ -5,11 +5,25 @@ is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "gemma3:4b" }
+platform_llm_id = { custom_llm = "gemma3:4b" }
 
 [custom-llama-4."llama4:scout".latest]
 is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "llama4:scout" }
+platform_llm_id = { custom_llm = "llama4:scout" }
+
+["custom-mistral-small3.1"."mistral-small3.1".latest]
+is_gen_object_supported = false
+is_vision_supported = true
+max_prompt_images = 3000
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "mistral-small3.1:24b" }
+
+["custom-qwen3"."qwen3:8b".latest]
+is_gen_object_supported = false
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "qwen3:8b" }
+# TODO: support <think> tokens

--- a/pipelex_mcp/pipelex_libraries/llm_integrations/vertexai.toml
+++ b/pipelex_mcp/pipelex_libraries/llm_integrations/vertexai.toml
@@ -5,32 +5,39 @@ is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.075, output = 0.3 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-flash" }
+platform_llm_id = { vertexai = "google/gemini-1.5-flash" }
 
 [gemini."gemini-1.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 1.25, output = 5.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-pro" }
+platform_llm_id = { vertexai = "google/gemini-1.5-pro" }
 
 [gemini."gemini-2.0-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.1, output = 0.4 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.0-flash" }
+platform_llm_id = { vertexai = "google/gemini-2.0-flash" }
 
 [gemini."gemini-2.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.0, output = 0.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-pro-preview-05-06" }
+platform_llm_id = { vertexai = "google/gemini-2.5-pro-preview-05-06" }
+
+[gemini."gemini-2.5-flash"."2025-04-17"]
+is_gen_object_supported = true
+is_vision_supported = true
+max_prompt_images = 3000
+cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-04-17" }
 
 [gemini."gemini-2.5-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-flash-preview-04-17" }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-05-20" }

--- a/pipelex_mcp/pipelex_libraries/llm_integrations/xai.toml
+++ b/pipelex_mcp/pipelex_libraries/llm_integrations/xai.toml
@@ -1,0 +1,25 @@
+
+[grok-3.grok-3.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 3, output = 15 }
+platform_llm_id = { xai = "grok-3-latest" }
+
+[grok-3.grok-3-mini.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0.3, output = 0.5 }
+platform_llm_id = { xai = "grok-3-mini-latest" }
+
+[grok-3.grok-3-fast.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 5, output = 25 }
+platform_llm_id = { xai = "grok-3-fast-latest" }
+
+
+[grok-3.grok-3-mini-fast.latest]
+is_gen_object_supported = true
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0.15, output = 4 }
+platform_llm_id = { xai = "grok-3-mini-fast-latest" }

--- a/pipelex_mcp/pipelex_libraries/pipelines/base_library/documents.toml
+++ b/pipelex_mcp/pipelex_libraries/pipelines/base_library/documents.toml
@@ -16,3 +16,11 @@ output = "PageContent"
 pdf = "pdf"
 page_images = true
 page_views = false
+
+[pipe.extract_page_contents_and_views_from_pdf]
+PipeOcr = "Extract page contents from a PDF document as well aspage views"
+input = "PDF"
+output = "PageContent"
+pdf = "pdf"
+page_images = true
+page_views = true

--- a/pipelex_mcp/pipelex_libraries/pipelines/base_library/questions.py
+++ b/pipelex_mcp/pipelex_libraries/pipelines/base_library/questions.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from enum import StrEnum
 from typing import Generic, List, Literal, Optional, TypeVar, Union
 
-from pipelex import pretty_print
 from pipelex.core.stuff_content import StructuredContent
+from pipelex.types import StrEnum
 from pydantic import Field, model_validator
 from typing_extensions import Self, override
 
@@ -58,12 +57,6 @@ class ThoughtfulAnswer(StructuredContent):
     the_counter: str
     the_lesson: str
     the_answer: str
-
-    def pretty_print(self):
-        pretty_print(self.the_trap, title="The trap", border_style="bright_red")
-        pretty_print(self.the_counter, title="The counter", border_style="bright_yellow")
-        pretty_print(self.the_lesson, title="The lesson", border_style="blue")
-        pretty_print(self.the_answer, title="The answer", border_style="green")
 
 
 T = TypeVar("T")

--- a/pipelex_mcp/server.py
+++ b/pipelex_mcp/server.py
@@ -8,7 +8,7 @@ from pipelex.core.stuff_content import ImageContent, ListContent
 from pipelex.core.working_memory_factory import WorkingMemoryFactory
 from pipelex.hub import get_pipe_provider
 from pipelex.pipelex import Pipelex
-from pipelex.run import run_pipe_code
+from pipelex.pipeline.execute import execute_pipeline
 
 LOG_DIR = Path("./logs")
 LOG_DIR.mkdir(exist_ok=True)
@@ -78,7 +78,7 @@ async def generate_company_mascott(company_context: str) -> ListContent[ImageCon
         text=company_context, concept_code="mascot_generation.CompanyContext", name="company_context"
     )
 
-    pipe_output = await run_pipe_code(pipe_code="generate_mascot_options", working_memory=working_memory)
+    pipe_output, _ = await execute_pipeline(pipe_code="generate_mascot_options", working_memory=working_memory)
 
     # Example of using mcp_print for MCP communication
     mcp_print("Output the links of the images, and a one line description of the image")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-mcp"
-version = "0.0.2"
+version = "0.0.3"
 description = "Pipelex MCP Server: Pipelex is an open-source dev tool based on a simple declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -14,7 +14,7 @@ classifiers = [
 
 dependencies = [
     "mcp[cli]>=1.6.0",
-    "pipelex[mistralai,anthropic,google,bedrock,fal]>=0.2.9",
+    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.2.14",
 ]
 [project.urls]
 Homepage = "https://pipelex.com"

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.7.2"
+version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -442,9 +442,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/ba/692739c76959191aa7e5f0fccda871b36548355f4a09c8733687e64e62b0/instructor-1.7.2.tar.gz", hash = "sha256:6c01b2b159766df24865dc81f7bf8457cbda88a3c0bbc810da3467d19b185ed2", size = 66200177, upload-time = "2024-12-26T09:04:57.209Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/54/927c2093dc5e532195baf849f7ff1376ad673222b5d37be19e4e73af618e/instructor-1.8.3.tar.gz", hash = "sha256:04d64ebc0d6e5eee104f4715b18fac1a02c21757ae6ce76efa65d38cbd536b0b", size = 69265823, upload-time = "2025-05-22T16:44:02.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/82/fd319382c1a33d7021cf151007b4cbd5daddf09d9ca5fb670e476668f9fc/instructor-1.7.2-py3-none-any.whl", hash = "sha256:cb43d27f6d7631c31762b936b2fcb44d2a3f9d8a020430a0f4d3484604ffb95b", size = 71353, upload-time = "2024-12-26T09:04:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/07/76/0e198373f182020559b0886d0d61dd2ddca109ab7a9eddf5458ff759d51a/instructor-1.8.3-py3-none-any.whl", hash = "sha256:a2c5066458132dc50ec6faa87cab9a2dd6b11b3f45c0e563a2ef704892286945", size = 94619, upload-time = "2025-05-22T16:43:58.529Z" },
 ]
 
 [[package]]
@@ -505,15 +505,14 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
-    { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/1e/7eb1a10f04b67efbac1026a629a22bf55d68f915ecb58aeae7e6453de729/kajson-0.1.4.tar.gz", hash = "sha256:61f11fb3452afad9cf9c53febe1f2f28af3d2fe8744fb7cc17fd0732e46fccb0", size = 14533, upload-time = "2025-05-25T15:53:51.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/38/300e06d9e5c98d2bcb922e3d2813836f74754a117bcf5c9ff019a20eea0b/kajson-0.1.5.tar.gz", hash = "sha256:cf166e417642127e4a4bca3d31788b64fcd1969f6bc103df2fa59e069c27b8a8", size = 15061, upload-time = "2025-06-02T15:28:52.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/ea/6417590de6edcaff1a7520b4305bfca66183090c1e46a21951abfd883798/kajson-0.1.4-py3-none-any.whl", hash = "sha256:fbea1ae670744f91ccd8754adf9fa98315aa2b9bd20d76be753cb86771eaa131", size = 18587, upload-time = "2025-05-25T15:53:49.6Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/7c/12f2167e1b1056e73224b7c4f8062807af47f0bc6a26ef773e3f8219c773/kajson-0.1.5-py3-none-any.whl", hash = "sha256:5fbc4065fa85f56dccf93d644a9d3ee1bccb504d7f27f030a1beacc6ba21e1d6", size = 21090, upload-time = "2025-06-02T15:28:50.765Z" },
 ]
 
 [[package]]
@@ -795,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.2.9"
+version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -822,9 +821,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yattag" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/b4/0da2089e36e7284bbde7da6234f0dc8576b78f0fa51747df925f3de443be/pipelex-0.2.9.tar.gz", hash = "sha256:197a0b765d457f903f528f51b3d567e71503d51c8f50b2aea1e1eef4d9f0fde2", size = 157571, upload-time = "2025-05-30T14:24:16.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/73/a753b613053b4158f8fa0cbd34ea42fc096811b3662b7b9b05d2254febc9/pipelex-0.2.14.tar.gz", hash = "sha256:65545ed6bf98faa6dd1aab9aa72ae967566c385a215e43752dcfc78ca1790e10", size = 161820, upload-time = "2025-06-06T15:40:47.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/75/173306a501fe1fc6e64b1b0f2a7f0e974cce391c9fe21792db022d48a307/pipelex-0.2.9-py3-none-any.whl", hash = "sha256:3c224f4235c6c5fc29b4c3c5a8c2113981f9c48cb617ef5ae3ae0a411aebf7d0", size = 265961, upload-time = "2025-05-30T14:24:14.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/17c318d6ae95c2518b02dcba56864188640a0f8e5e572d1568a8d5400b8b/pipelex-0.2.14-py3-none-any.whl", hash = "sha256:2b6f8e43bbf786361fae123f2a3949b7794661570b3f2fe6499c3f3664f26319", size = 272260, upload-time = "2025-06-06T15:40:45.433Z" },
 ]
 
 [package.optional-dependencies]
@@ -847,7 +846,7 @@ mistralai = [
 
 [[package]]
 name = "pipelex-mcp"
-version = "0.0.1"
+version = "0.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -868,7 +867,7 @@ dev = [
 requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = ">=0.2.9" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = "==0.2.14" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.381" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION

## [v0.0.3] - 2025-06-06

- Bumped pipelex to v0.2.14: generalized the new `execute_pipeline` method, enabling to track pipelines from beginning to end with inference cost reporting